### PR TITLE
Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Exclude the Go workspace cache
+/pkg
+/bin
+# Exclude version control files
+.git
+.gitignore
+
+# Exclude local Go mod cache
+go.sum
+go.mod
+
+# Exclude editor and IDE settings
+*.swp
+*.swo
+*.idea/
+.vscode/
+*.iml
+
+# Exclude binaries and executables
+*.exe
+*.out
+*.so
+*.o
+*.a
+
+# Exclude log files and temporary files
+*.log
+*.tmp
+*.bak
+
+# Exclude Dockerfile itself (not needed in the image)
+Dockerfile
+
+# Other files to exclude
+README.md
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# ---> Go
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.o
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+idea/
+.idea/
+
+# Go workspace file
+go.work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,37 @@
+# Build stage
 FROM golang:1.23.1-alpine3.20 AS build
 
+# Set the working directory inside the container
 WORKDIR /app
+
+COPY go.mod go.sum ./
+
+# Cache dependencies (unless change in go.mod)
+RUN go mod download
 
 COPY . .
 
 RUN go test --cover -v ./...
+
 RUN go build -v -o forum-go
 
+# Final stage: minimal image for development
 FROM alpine:latest
 
-LABEL authors=""\ #TODO: Add contributor
-      description=""\ #TODO: Add description, maybe?
-      licence="GNU GPL V3.0-or-later"\
-      maintainer="See author label"\
+LABEL authors="TODO: Add contributors" \
+      description="TODO: Add description, maybe?" \
+      license="GNU GPL V3.0-or-later" \
+      maintainer="See author label" \
       contact="See author label"
 
 WORKDIR /app
+
 COPY --from=build /app/forum-go /app/forum-go
+
+# Copy the source code for development purposes
 COPY --from=build /app/src /app/src
 
 EXPOSE 3000
 
 CMD ["/app/forum-go"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.23.1-alpine3.20 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN go test --cover -v ./...
+RUN go build -v -o forum-go
+
+FROM alpine:latest
+
+LABEL authors=""\ #TODO: Add contributor
+      description=""\ #TODO: Add description, maybe?
+      licence="GNU GPL V3.0-or-later"\
+      maintainer="See author label"\
+      contact="See author label"
+
+WORKDIR /app
+COPY --from=build /app/forum-go /app/forum-go
+COPY --from=build /app/src /app/src
+
+EXPOSE 3000
+
+CMD ["/app/forum-go"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # forum-go
+
+## 💻 Docker Setup
+
+You can easily run the project using Docker and Docker Compose. Follow these steps to get the application up and running in a Docker container.
+
+#### Step 1: Build and Run the Container
+
+To build and run the application, execute the following command:
+
+```shell
+docker-compose up --build -d
+```
+
+- `up`: This command creates and starts the Docker containers defined in the `docker-compose.yml` file.
+- `--build`: This flag ensures that Docker Compose builds the image before starting the container. It’s useful when changes are made to the code or Dockerfile, and you want to rebuild the image.
+- `-d`: This flag runs the container in detached mode, meaning it runs in the background, freeing up your terminal for other tasks.
+
+Once the command completes, the application will be running in a Docker container, and you can access it on `localhost:3000` (or another port if specified).
+
+#### Step 2: Stop and Remove the Container
+
+When you are done with the container or need to stop it, you can use the following command to stop and remove the running container:
+
+```shell
+docker-compose down
+```
+
+This will stop the application and clean up the containers, networks, and volumes created by Docker Compose. It's a good way to ensure that the environment is reset when you're done.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  app:
+    image: forum-go:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+


### PR DESCRIPTION
## Summary

This PR adds Docker setup for the projetc and includes a `.dockerignore` file for optimization of the building process. In the meantime, `README` file was modified and provide documentation building and stopping container.

### Key changes:

- **Dockerfile**: A multi-stage Dockerfile has been added to build the application in a lightweight Alpine image.
  - Ensures application is build and run in a production-ready environment.
  - The application listens oon port 3000

- **docker-compose.yml**: Added a Docker compose file for runnning the application in production mode.
  - simplifies runnning the application in a contenerized environment.
  - Build the Docker image using the Dockerfile and maps the application's port (3000) to the host.

- **.dockerignore**: Needed to exclude unnecessary files from the docker image, reducing the finale image size and speeding up the building process. 

## How to test

1. Run `docker-compose up --build -d` to build the docker image and start the application in detached mode.
2. Visit `http://localhost:3000` to verify if the application is correctly running.
3. Run `docker-compose down` to stop and remove the container.

## Notes

⚠️ as server has not been yet implemented, testing docker container may be somewhat impossible.